### PR TITLE
Reverts to dummy response instead of a compile dep on google's empty

### DIFF
--- a/zipkin.proto
+++ b/zipkin.proto
@@ -228,5 +228,5 @@ service SpanService {
   // Report the provided spans to the collector. Analogous to the HTTP POST 
   // /api/v2/spans endpoint. Spans are not required to be complete or belonging 
   // to the same trace.
-  rpc Report(zipkin.proto3.ListOfSpans) returns (ReportResponse) {}
+  rpc Report(ListOfSpans) returns (ReportResponse) {}
 }

--- a/zipkin.proto
+++ b/zipkin.proto
@@ -214,7 +214,8 @@ message ListOfSpans {
 }
 
 // Response for SpanService/Report RPC. This response currently does not return
-// any information beyond indicating that the request has finished.
+// any information beyond indicating that the request has finished. That said,
+// it may be extended in the future.
 message ReportResponse {
 }
 

--- a/zipkin.proto
+++ b/zipkin.proto
@@ -14,8 +14,6 @@
 
 syntax = "proto3";
 
-import "google/protobuf/empty.proto";
-
 package zipkin.proto3;
 
 // In Java, the closest model type to this proto is in the "zipkin2" package
@@ -215,6 +213,10 @@ message ListOfSpans {
   repeated Span spans = 1;
 }
 
+// Response for SpanService/Report RPC. This response currently does not return
+// any information beyond indicating that the request has finished.
+message ReportResponse {
+}
 
 // SpanService allows reporting spans using gRPC, as opposed to HTTP POST 
 // reporting. Implementations are asynchronous and may drop spans for reasons 
@@ -226,5 +228,5 @@ service SpanService {
   // Report the provided spans to the collector. Analogous to the HTTP POST 
   // /api/v2/spans endpoint. Spans are not required to be complete or belonging 
   // to the same trace.
-  rpc Report(zipkin.proto3.ListOfSpans) returns (google.protobuf.Empty) {}
+  rpc Report(zipkin.proto3.ListOfSpans) returns (ReportResponse) {}
 }


### PR DESCRIPTION
Empty is the only thing that requires a compile dependency on google
(not standard proto) types. For example, if you use square wire
compiler, you need to add a google library now to compile our proto.

Since we haven't really released the service, yet, and empty is binary
compatible with an equally empty response, we can change.

This reverts to what @ewhauser had originally, which makes things
more portable.