### PR TITLE
Adds missing disclaimer

### DIFF
--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,5 @@
+Apache Zipkin (incubating) is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by the Apache Incubator PMC.
+Incubation is required of all newly accepted projects until a further review indicates 
+that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. 
+While incubation status is not necessarily a reflection of the completeness or stability of the code, 
+it does indicate that the project has yet to be fully endorsed by the ASF.

--- a/src/main/assemblies/source-release.xml
+++ b/src/main/assemblies/source-release.xml
@@ -31,6 +31,7 @@
       <outputDirectory/>
       <includes>
         <include>LICENSE</include>
+        <include>DISCLAIMER</include>
         <include>NOTICE</include>
         <include>README.md</include>
         <include>thrift/*.thrift</include>


### PR DESCRIPTION
```bash
$ GPG_TTY=$(tty) ./mvnw clean install -Papache-release
--snip--
$ jar -tvf target/apache-zipkin-api-incubating-0.2.2-SNAPSHOT-source-release.zip
     0 Fri Apr 26 07:40:30 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/
     0 Fri Apr 26 07:40:30 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/thrift/
 20678 Wed Apr 24 15:42:18 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/zipkin2-api.yaml
 10147 Wed Apr 24 15:42:18 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/zipkin.proto
 11357 Tue Apr 16 14:11:20 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/LICENSE
   553 Fri Apr 26 07:35:44 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/DISCLAIMER
 16262 Wed Apr 24 15:42:18 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/zipkin-api.yaml
   747 Fri Apr 26 07:35:26 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/README.md
   220 Wed Apr 24 15:42:18 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/NOTICE
  1474 Wed Apr 24 15:42:18 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/thrift/zipkinDependencies.thrift
 19730 Wed Apr 24 15:42:18 MYT 2019 zipkin-api-0.2.2-SNAPSHOT/thrift/zipkinCore.thrift
```
